### PR TITLE
fix: add libSystem to Valgrind LDFLAGS

### DIFF
--- a/valgrind.rb
+++ b/valgrind.rb
@@ -29,6 +29,8 @@ class Valgrind < Formula
       --prefix=#{prefix}
     ]
 
+    ENV.append "LDFLAGS", "-lSystem"
+
     if ENV["HOMEBREW_I_ACKNOWLEDGE_THIS_MIGHT_CRASH_OR_DAMAGE_MY_COMPUTER"] == "yes"
       ENV["I_ACKNOWLEDGE_THIS_MIGHT_CRASH_OR_DAMAGE_MY_COMPUTER"] = "yes"
     end


### PR DESCRIPTION
Linking libmydyld.so without libSystem causes dyld to reject it at runtime on macOS with:
  ```
  missing LC_LOAD_DYLIB (must link with at least libSystem.dylib)
  ```
Appending `-lSystem` to `LDFLAGS` makes `libmydyld.so` include the required libSystem dependency.

Test without fix:
```
otool -L "$(brew --prefix valgrind)/libexec/valgrind/libmydyld.so"
/opt/homebrew/opt/valgrind/libexec/valgrind/libmydyld.so:
	/opt/homebrew/opt/valgrind/libexec/valgrind/libdyld.dylib (compatibility version 0.0.0, current version 0.0.0)
```
	
Test with fix:
```
otool -L "$(brew --prefix valgrind)/libexec/valgrind/libmydyld.so" 
/opt/homebrew/opt/valgrind/libexec/valgrind/libmydyld.so:
	/opt/homebrew/opt/valgrind/libexec/valgrind/libdyld.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
```
The resulting libmydyld.so now links against `/usr/lib/libSystem.B.dylib`, and `valgrind` works.
I tested this locally and it fixes the issue on my machine.

I am not completely sure whether this is the correct fix for all supported macOS versions and architectures, so additional testing from other users affected by the same error would be appreciated :-)